### PR TITLE
Provide an option to not verify the domain

### DIFF
--- a/giturlparse/__init__.py
+++ b/giturlparse/__init__.py
@@ -3,8 +3,8 @@ from giturlparse.parser import parse as _parse
 from giturlparse.result import GitUrlParsed
 
 
-def parse(url):
-	return GitUrlParsed(_parse(url))
+def parse(url, check_domain=True):
+	return GitUrlParsed(_parse(url, check_domain))
 
-def validate(url):
-    return parse(url).valid
+def validate(url, check_domain=True):
+    return parse(url, check_domain).valid

--- a/giturlparse/parser.py
+++ b/giturlparse/parser.py
@@ -15,7 +15,7 @@ SUPPORTED_ATTRIBUTES = (
 )
 
 
-def parse(url):
+def parse(url, check_domain=True):
     # Values are None by default
     parsed_info = defaultdict(lambda: None)
 
@@ -35,9 +35,10 @@ def parse(url):
             # Skip if domain is bad
             domain = match.group('domain')
             #print('[%s] DOMAIN = %s' % (url, domain,))
-            if platform.DOMAINS and not(domain in platform.DOMAINS):
-                #print("domain: %s not in %s" % (domain, platform.DOMAINS))
-                continue
+            if check_domain:
+                if platform.DOMAINS and not(domain in platform.DOMAINS):
+                    #print("domain: %s not in %s" % (domain, platform.DOMAINS))
+                    continue
 
             # Get matches as dictionary
             matches = match.groupdict()


### PR DESCRIPTION
Domains are not always easily specified. With things like GitHub
Enterprise and other "non-standard" domains, this parsing method
will short-circuit.

Therefore provide a mechanism to disable domain verification.
